### PR TITLE
Convert relative paths to absolute when checking links

### DIFF
--- a/example/docs/tests/a/index.md
+++ b/example/docs/tests/a/index.md
@@ -2,15 +2,15 @@
 
 This file is the index.md in the `a` folder. It appears on the path as with a trailing slash.
 
-To link relatively to the folder `b` you should use, [b/](b/) or [b/index](b/index) the last has the advantage that is also works in the raw markdown. A full link is also valid [/tests/a/b/](/tests/a/b/) or [/tests/a/b/index](/tests/a/b/index) linking to headings is also supported [b/#link-test](b/#link-test) and [b/index#link-test](b/index#link-test).
+To link relatively to the folder `b` you should use, [b/](b/) or [b/index](b/index) the last has the advantage that is also works in the raw markdown. A full link is also valid [/tests/a/b/](/tests/a/b/) or [/tests/a/b/index](/tests/a/b/index) linking to headings is also supported [b/#link-test](b/#link-test) and [b/index#link-test](b/index#link-test). 
+
+You can also link 'up' directories, for example: [../a](../a), [../a/mdTest](../../tests/mdTest), [../../tests/a/b#link-test](../../tests/a/b#link-test)
 
 We consider paths as case insensitive, so the following also work [B/](B/) or [B/Index](B/Index).
 
 The following are invalid.
 
 ```markdown
-[../](../) // not supported
-[../a](../a) // not supported
 [a/b/c/d](a/b/c/d) // missing
 [b/#link-test](b/#link-tests) // missing
 ```

--- a/example/docs/tests/a/index.md
+++ b/example/docs/tests/a/index.md
@@ -4,7 +4,7 @@ This file is the index.md in the `a` folder. It appears on the path as with a tr
 
 To link relatively to the folder `b` you should use, [b/](b/) or [b/index](b/index) the last has the advantage that is also works in the raw markdown. A full link is also valid [/tests/a/b/](/tests/a/b/) or [/tests/a/b/index](/tests/a/b/index) linking to headings is also supported [b/#link-test](b/#link-test) and [b/index#link-test](b/index#link-test). 
 
-You can also link 'up' directories, for example: [../a](../a), [../a/mdTest](../../tests/mdTest), [../../tests/a/b#link-test](../../tests/a/b#link-test)
+You can also link 'up' directories, for example: [../a](../a), [../../tests/mdTest](../../tests/mdTest), [../../tests/a/b#link-test](../../tests/a/b#link-test)
 
 We consider paths as case insensitive, so the following also work [B/](B/) or [B/Index](B/Index).
 

--- a/example/package.json
+++ b/example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "example",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "index.js",
   "author": "Committed <opensource@committed.io>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@committed/gatsby-theme-docs-workspace",
   "private": true,
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "index.js",
   "license": "MIT",
   "scripts": {

--- a/theme/package.json
+++ b/theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@committed/gatsby-theme-docs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "main": "index.js",
   "author": "Committed <opensource@committed.io>",
   "license": "MIT",

--- a/theme/plugins/check-links/index.js
+++ b/theme/plugins/check-links/index.js
@@ -6,21 +6,23 @@ function getCacheKey(node) {
   return `check-links-${node.id}-${node.internal.contentDigest}`
 }
 
-function getPosition(string, subString, index) {
-  return string.split(subString, index).join(subString).length;
+function getNthPosition(string, subString, n) {
+  return string.split(subString, n).join(subString).length;
+}
+
+function convertToAbsolutePath(link, path) {
+  const moveUpDirectoryCount = (link.match(/\.\.\//g) || []).length
+  let pathWithoutTrailingSlash = path[path.length - 1] === '/' ? path.slice(0, path.length - 1) : path
+  const pathSlashCount = (path.match(/\//g) || []).length
+  const indexToSliceTo = getNthPosition(pathWithoutTrailingSlash, '/', pathSlashCount - moveUpDirectoryCount) + 1
+  const slicedPath = pathWithoutTrailingSlash.slice(0, indexToSliceTo)
+  const slicedLink = link.slice(moveUpDirectoryCount * 3, link.length)
+  return slicedPath.concat(slicedLink)
 }
 
 function convertToBasePath(link, path) {
   if (link.startsWith('../')) {
-    // Convert the relative link to an absolute one
-    const moveUpDirectoryCount = (link.match(/\.\.\//g) || []).length
-    let pathWithoutTrailingSlash = path[path.length - 1] === '/' ? path.slice(0, path.length - 1) : path
-    const pathSlashCount = (path.match(/\//g) || []).length
-    const indexToSliceTo = getPosition(pathWithoutTrailingSlash, '/', pathSlashCount - moveUpDirectoryCount) + 1
-    const slicedPath = pathWithoutTrailingSlash.slice(0, indexToSliceTo)
-    const slicedLink = link.slice(moveUpDirectoryCount * 3, link.length)
-    const concat = slicedPath.concat(slicedLink)
-    return concat.toLowerCase()
+    return convertToAbsolutePath(link, path).toLowerCase()
   }
   return link.toLowerCase().replace(/^\.\//, '') // strip ./
 

--- a/theme/plugins/check-links/index.js
+++ b/theme/plugins/check-links/index.js
@@ -6,8 +6,28 @@ function getCacheKey(node) {
   return `check-links-${node.id}-${node.internal.contentDigest}`
 }
 
+function getPosition(string, subString, index) {
+  return string.split(subString, index).join(subString).length;
+}
+
+function convertToBasePath(link, path) {
+  if (link.startsWith('../')) {
+    // Convert the relative link to an absolute one
+    const moveUpDirectoryCount = (link.match(/\.\.\//g) || []).length
+    let pathWithoutTrailingSlash = path[path.length - 1] === '/' ? path.slice(0, path.length - 1) : path
+    const pathSlashCount = (path.match(/\//g) || []).length
+    const indexToSliceTo = getPosition(pathWithoutTrailingSlash, '/', pathSlashCount - moveUpDirectoryCount) + 1
+    const slicedPath = pathWithoutTrailingSlash.slice(0, indexToSliceTo)
+    const slicedLink = link.slice(moveUpDirectoryCount * 3, link.length)
+    const concat = slicedPath.concat(slicedLink)
+    return concat.toLowerCase()
+  }
+  return link.toLowerCase().replace(/^\.\//, '') // strip ./
+
+}
+
 function getHeadingsMapKey(link, path) {
-  let basePath = link.toLowerCase().replace(/^\.\//, '') // strip ./
+  let basePath = convertToBasePath(link, path)
   const hashIndex = basePath.indexOf('#')
   const hasHash = hashIndex !== -1
   const hashId = hasHash ? basePath.slice(hashIndex + 1) : null
@@ -121,7 +141,8 @@ module.exports = async (
           return false
         }
 
-        const headings = headingsMap[key]
+        // If no heading is found, try again with a trailing /
+        const headings = headingsMap[key] == null ? headingsMap[`${key}/`] : headingsMap[key]
         if (headings) {
           if (hasHash) {
             return (


### PR DESCRIPTION
This solution takes a relative link to check (eg `../../test/a`) and converts it to an absolute link (`/docs/test/a`). 

This also adds a second attempt at finding headers for links - ie if finding headers for `/a` fails, then try again for `/a/` 

Closes #28 