### PR TITLE
Add remark preprocessor to remove trailing .md from links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A theme for writing documentation sites in Markdown.
 - SEO friendly
 - Fully customizable
 - 🔍 Search
+- Use links that work in github
 
 ## 🔗 Live Demo and Instructions
 
@@ -114,7 +115,7 @@ Canonical URLs are generated automatically.
 
 ## Development
 
-We use yarn workspaces to develop the theme alongside an example usage that also serves as a documentation site for this project.
+We use workspaces to develop the theme alongside an example usage that also serves as a documentation site for this project.
 
 On first use run
 
@@ -161,5 +162,5 @@ site of someone who installed and used your theme.
 You can run the example with:
 
 ```shell
-yarn workspace example develop
+npm run start
 ```

--- a/example/docs/instructions.md
+++ b/example/docs/instructions.md
@@ -43,7 +43,7 @@ Further options are available to customize, detailed below.
 
 The `index.md(x)` file is shown on load.
 
-Each documentation page can add frontmatter that is used to improve SEO. You can add metadata, [order](ordered/index) the pages and add user friendly links:
+Each documentation page can add frontmatter that is used to improve SEO. You can add metadata, [order](ordered/index.md) the pages and add user friendly links:
 
 ```markup
 ---
@@ -56,7 +56,7 @@ metaTescription: "This is the meta tag description, , but will default to descri
 ---
 ```
 
-If no title is provided the filename is used. The sidebar is populated from the files in `docs` folder and supports [nesting](nested/index) in sub-folders. At each level the contents are sorted using alphanumerically using the order frontmatter or the title.
+If no title is provided the filename is used. The sidebar is populated from the files in `docs` folder and supports [nesting](nested/index.md) in sub-folders. At each level the contents are sorted using alphanumerically using the order frontmatter or the title.
 
 ## Navigation
 

--- a/example/docs/ordered/oa.md
+++ b/example/docs/ordered/oa.md
@@ -3,4 +3,4 @@ title: Order A
 order: '2'
 ---
 
-In this example although the title `Order A` is before [`Order B`](ob) the `order` front matter is used to sort the files.
+In this example although the title `Order A` is before [`Order B`](ob.md) the `order` front matter is used to sort the files.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       }
     },
     "example": {
-      "version": "2.1.2",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@committed/gatsby-theme-docs": "^3.0.0",
@@ -22830,7 +22830,7 @@
     },
     "theme": {
       "name": "@committed/gatsby-theme-docs",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "@committed/components": "^4.2.1",

--- a/theme/gatsby-config.js
+++ b/theme/gatsby-config.js
@@ -71,6 +71,9 @@ module.exports = ({
         ],
         gatsbyRemarkPlugins: [
           {
+            resolve: require.resolve(`./plugins/fix-links`),
+          },
+          {
             resolve: require.resolve(`./plugins/fix-mermaid-pre`),
           },
           {

--- a/theme/plugins/fix-links/index.js
+++ b/theme/plugins/fix-links/index.js
@@ -1,0 +1,14 @@
+const visit = require('unist-util-visit')
+module.exports = ({ markdownAST }, pluginOptions) => {
+  const protocols = ['mailto:', 'http://', 'ftp:', 'https://']
+
+  visit(markdownAST, 'link', (node) => {
+    // Any link we find which isn't internal, then ignore it
+    if (protocols.find((p) => node.url.startsWith(p))) {
+      return
+    }
+    const old = node.url
+    node.url = node.url.replace(/\.md$/, '')
+  })
+  return markdownAST
+}

--- a/theme/plugins/fix-links/package.json
+++ b/theme/plugins/fix-links/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "fix-links",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Committed Software <support@committed.io> (http://committed.io)",
+  "license": "MIT"
+}


### PR DESCRIPTION
fix #51
