### PR TITLE
fix(ci): fixes issue with ci script stopping the docs deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,14 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ env.NODE_VERSION }}
+      - name: Restore dependencies
+        uses: actions/cache@v2
+        id: cache-dependencies
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-npm-
       - name: Download build artifacts
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
was missing the gh-pages as the npm cache was not restored - marked as feature so to test the
deployment
