### PR TITLE
fix: add readme to deployed package

### DIFF
--- a/theme/package.json
+++ b/theme/package.json
@@ -27,7 +27,7 @@
     "build": "cp ../README.md .",
     "deploy": "npm publish --access public",
     "deploy:ci": "npm run deploy",
-    "semantic-release": "semantic-release"
+    "semantic-release": "cp ../README.md . ; semantic-release"
   },
   "peerDependencies": {
     "gatsby": "^3.8.0",


### PR DESCRIPTION
The REadme is missing from the deply package, it is copied as part of the build but laost on change
of action. So added to the semantic release script directly.
